### PR TITLE
Support for "Local Variables:" at end of file

### DIFF
--- a/plugin/emacsmodeline.vim
+++ b/plugin/emacsmodeline.vim
@@ -27,15 +27,16 @@
 "  * Prevent an exploit.  Not seen in the wild, but likely to be used by vengeful emacs users.
 " 1.2, Jun 07, 2015:
 "  * More file support.  Let vim provide defaults.
-"
+" 1.x, xxx xx, xxxx:
+"  * More rigidly adhere to emacs' own behaviour, as described at
+"    https://www.gnu.org/software/emacs/manual/html_node/emacs/Specifying-File-Variables.html
+"    ie: only support '-*-' in the first 2 lines, but also support
+"    'Local Variables:' in the last 3000 chars, and set the latter after
+"    the former.
 
 " No attempt is made to support vim versions before 7.0.
 if version < 700
     finish
-endif
-
-if (!exists("g:emacs_modelines"))
-    let g:emacs_modelines=5
 endif
 
 " Note: Entries to emacsModeDict must be lowercase. E. g. 'makefile' instead of 'Makefile'.
@@ -82,6 +83,15 @@ function! <SID>SetVimNumberOption(modeline, emacs_name, vim_name)
     return 0
 endfunc
 
+function! <SID>SetVimStringOption(modeline, emacs_name, vim_name, validate_pattern)
+    let value = <SID>FindParameterValue(a:modeline, a:emacs_name, a:validate_pattern)
+    if strlen(value)
+        exec 'setlocal ' . a:vim_name . '=' . value
+        return 1
+    endif
+    return 0
+endfunc
+
 function! <SID>SetVimToggleOption(modeline, emacs_name, vim_name, nil_value)
     let value = <SID>FindParameterValue(a:modeline, a:emacs_name, '[^;[:space:]]\+')
     if strlen(value)
@@ -93,51 +103,87 @@ function! <SID>SetVimToggleOption(modeline, emacs_name, vim_name, nil_value)
     endif
 endfunc
 
-function! ParseEmacsModeLine()
-    " Prepare to scan the first and last g:emacs_modelines lines.
-    let max = line("$")
-    if max > (g:emacs_modelines * 2)
-        let lines = range(1, g:emacs_modelines) + range(max - g:emacs_modelines + 1, max)
-    else
-        let lines = range(1, max)
+function! <SID>ParseEmacsOption(modeline)
+
+    call <SID>SetVimModeOption(a:modeline)
+
+    call <SID>SetVimNumberOption(a:modeline, 'fill-column',        'textwidth')
+    if <SID>SetVimNumberOption(a:modeline,   'tab-width',          'tabstop')
+        " - When shiftwidth is zero, the 'tabstop' value is used.
+        "   Use the shiftwidth() function to get the effective shiftwidth value.
+        " - When 'sts' is negative, the value of 'shiftwidth' is used.
+        setlocal shiftwidth=0
+        setlocal softtabstop=-1
     endif
+    call <SID>SetVimNumberOption(a:modeline, 'c-basic-offset',     'softtabstop')
+    call <SID>SetVimNumberOption(a:modeline, 'c-basic-offset',     'shiftwidth')
+
+    call <SID>SetVimToggleOption(a:modeline, 'buffer-read-only',   'readonly',     0)
+    call <SID>SetVimToggleOption(a:modeline, 'indent-tabs-mode',   'expandtab',    1)
+    call <SID>SetVimStringOption(a:modeline, 'coding',             'fileencoding', '[\w\-]\+')
+
+    let value = substitute(a:modeline, '^ *\([^ ]*\) *$', '\L\1', '')
+    if (has_key(g:emacsModeDict, value))
+        exec 'setlocal filetype=' .  g:emacsModeDict[value]
+    endif
+
+    " Other emacs options seen in the wild include:
+    "  * c-file-style: no vim equivalent (?).
+    "  * compile-command: probably equivalent to &makeprg.  However, vim will refuse to
+    "    set it from a modeline, as a security risk, and we follow that decision here.
+    "  * mmm-classes: appears to be for other languages inline in HTML, e.g. PHP.
+    "  * package: equal to mode, in the one place I've seen it.
+    "  * syntax: equal to mode, in the one place I've seen it.
+endfunc
+
+function! ParseEmacsModeLine()
+    " Prepare to scan the first 2 lines.
+    let lines = range(1, 2)
 
     let pattern = '.*-\*-\(.*\)-\*-.*'
     for n in lines
         let line = getline(n)
         if line =~ pattern
             let modeline = substitute(line, pattern, '\1', '')
-
-            call <SID>SetVimModeOption(modeline)
-
-            call <SID>SetVimNumberOption(modeline, 'fill-column',        'textwidth')
-            if <SID>SetVimNumberOption(modeline,   'tab-width',          'tabstop')
-                " - When shiftwidth is zero, the 'tabstop' value is used.
-                "   Use the shiftwidth() function to get the effective shiftwidth value.
-                " - When 'sts' is negative, the value of 'shiftwidth' is used.
-                setlocal shiftwidth=0
-                setlocal softtabstop=-1
-            endif
-            call <SID>SetVimNumberOption(modeline, 'c-basic-offset',     'softtabstop')
-            call <SID>SetVimNumberOption(modeline, 'c-basic-offset',     'shiftwidth')
-
-            call <SID>SetVimToggleOption(modeline, 'buffer-read-only',   'readonly',     0)
-            call <SID>SetVimToggleOption(modeline, 'indent-tabs-mode',   'expandtab',    1)
-
-            let value = substitute(modeline, '^ *\([^ ]*\) *$', '\L\1', '')
-            if (has_key(g:emacsModeDict, value))
-                exec 'setlocal filetype=' .  g:emacsModeDict[value]
-            endif
-
-            " Other emacs options seen in the wild include:
-            "  * c-file-style: no vim equivalent (?).
-            "  * coding: text encoding.  Non-UTF-8 files are evil.
-            "  * compile-command: probably equivalent to &makeprg.  However, vim will refuse to
-            "    set it from a modeline, as a security risk, and we follow that decision here.
-            "  * mmm-classes: appears to be for other languages inline in HTML, e.g. PHP.
-            "  * package: equal to mode, in the one place I've seen it.
-            "  * syntax: equal to mode, in the one place I've seen it.
+            call <SID>ParseEmacsOption(modeline)
         endif
+    endfor
+
+    " Prepare to scan the last 3000 characters' worth of lines.
+    let lastline = line("$")
+    let bname = bufname("")
+    let fsize = getfsize(bname)
+    if fsize > 3000
+        let firstline = byte2line(fsize-3000)
+    else
+        let firstline = 1
+    endif
+
+    " Find the last line in the file that has 'Local Variables:' in it,
+    " to try and be reasonably sure we aren't hitting another use of
+    " that string. Use the comments around that string to filter out
+    " all but the option name and value, as emacs purportedly does.
+    let lines = range(lastline, firstline, -1)
+    let pattern = '^\(.*\)[ \t]*Local [vV]ariables:[ \t]*\(.*\)$'
+    for n in lines
+        let line = getline(n)
+        if line =~ 'End:'
+            let lastline = n - 1
+        elseif line =~ pattern
+            let firstline = n + 1
+            let cstart = substitute(line, pattern, '\1', '')
+            let cend = substitute(line, pattern, '\2', '')
+            break
+        endif
+    endfor
+
+    " Now actually parse the lines we've found.
+    let lines = range(firstline, lastline)
+    for n in lines
+        let modeline = getline(n)
+        let modeline = substitute(modeline, '^'.cstart, '', '')
+        let modeline = substitute(modeline, cend.'$', '', '')
+        call <SID>ParseEmacsOption(modeline)
     endfor
 endfunc
 


### PR DESCRIPTION
As per https://www.gnu.org/software/emacs/manual/html_node/emacs/Specifying-File-Variables.html , emacs also supports setting editor options at the end of the file (within the final 3000 characters) with a block of the format:

```
/* Local Variables:  */
/* mode: c           */
/* comment-column: 0 */
/* End:              */
```

These changes add support for this syntax. The patch also restricts support for '-*-' style modelines to the first 2 lines of the file, since the above source says that's all emacs parses.
